### PR TITLE
Dashboard UI enhancements: relative time, collapsible cards, 2FA badge

### DIFF
--- a/protonvpn_gluetun_updater.py
+++ b/protonvpn_gluetun_updater.py
@@ -255,9 +255,9 @@ _HTML_PAGE = """\
     details.card>summary{list-style:none;cursor:pointer;user-select:none;margin-bottom:0}
     details.card>summary::-webkit-details-marker{display:none}
     details.card>summary::marker{content:''}
-    details.card>summary::after{content:'\25b8';font-size:.75rem;float:right;color:#64748b;line-height:1.4}
+    details.card>summary::after{content:'\\25b8';font-size:.75rem;float:right;color:#64748b;line-height:1.4}
     details.card[open]>summary{margin-bottom:.8rem}
-    details.card[open]>summary::after{content:'\25be'}
+    details.card[open]>summary::after{content:'\\25be'}
     .filter-grid{display:grid;grid-template-columns:1fr 1fr;gap:.6rem 1.5rem;margin-top:.2rem}
     .filter-item label{display:block;font-size:.68rem;color:#64748b;text-transform:uppercase;letter-spacing:.08em;margin-bottom:.15rem}
     .filter-item .fval{font-size:.8rem;font-family:monospace;color:#e2e8f0}


### PR DESCRIPTION
## Summary

Enhances the web dashboard with improved UX and accessibility.

### Changes
- **Relative time display**: Last Run shows elapsed time (e.g. '5m ago', '30s ago', 'just now'); Next Run shows countdown (e.g. '2h 15m', 'in 30s') — computed client-side from raw Unix timestamps
- **Collapsible cards**: Filter Configuration and Last Run Statistics sections converted to `<details>`/`<summary>` elements with expand/collapse arrows
- **2FA badge**: Active/inactive status badge added to the 2FA card with animated 'waiting' state
- **Layout**: Status badge moved into the grid; 'Total Runs' removed to reduce clutter
- **Accessibility**: `aria-labelledby` added to filter stat items; `id` attributes on card/grid elements for JS targeting
- **Code quality**: explicit `encoding='utf-8'` on all file opens (including `_atomic_write()`); `_fmt_ts()` helper for formatting Unix timestamps

### Copilot Review Fixes — Round 1 (98d39c2)
- **Light-mode CSS**: Replaced generic `body.light .tfa-badge` color override with per-state rules (`.tfa-inactive`, `.tfa-waiting`) so the orange waiting badge color is preserved in light mode
- **2FA copy**: Updated UI text from '6-digit' to '6- to 8-digit' to match backend `re.fullmatch(r'\d{6,8}')` validation
- **API compatibility**: `/status` now includes backward-compatible `last_run`/`next_run` formatted string fields alongside the new raw `last_run_time`/`next_run_time` floats
- **Status label**: `waiting_2fa` now displays as 'waiting for 2FA' instead of 'authenticating'; `.s-waiting_2fa` CSS class is now correctly applied to the badge

### Copilot Review Fixes — Round 2 (857aa49)
- **`_atomic_write()` encoding**: Added `encoding='utf-8'` to `os.fdopen()` for consistency with all other file opens
- **Sub-60s relative time**: Added 'just now' (< 5s), 'Xs ago' / 'in Xs' (< 60s) fallbacks to avoid '0m ago'/'0m' appearing stuck immediately after or before a run
- **`nowSec` consistency**: `Date.now()/1000` is now computed once per `refresh()` call and reused for both last/next run calculations

### Copilot Review Fixes — Round 3 (fe6b81e)
- **Next Run 'just now' confusion**: Removed 'just now' branch for Next Run (a future time); sub-5s countdowns now display 'in 0s'..'in 4s' consistently with the `'in Xs'` format
- **Subtitle restored**: Re-added `<p class="sub">` so `.sub` CSS rules are no longer dead; added `text-align:center` to the rule
- **`::marker` CSS fix**: Replaced invalid `::marker{display:none}` with `::marker{content:''}` — `display` is not a valid `::marker` property; `list-style:none` on `summary` already handles hiding
- **`_fmt_ts()` helper**: Factored repeated `time.strftime(...time.localtime(...))` expressions into a single `_fmt_ts(ts)` helper used by the backward-compat `/status` fields

### Testing
- Syntax validated with `python -m py_compile`
- Rebased cleanly onto main
- `re.fullmatch(r'\d{6,8}')` 2FA validation preserved from main
